### PR TITLE
Add Enable Addons feature (Initial commit) - Attributed Slamious/BYB …

### DIFF
--- a/resources/libs/common/addonsEnable.py
+++ b/resources/libs/common/addonsEnable.py
@@ -1,0 +1,54 @@
+# Credit goes to Slamious and BYB. Altered for OpenWizard integration
+
+import glob, os, sqlite3
+import xbmc, xbmcaddon
+from xbmc import log
+from resources.libs.common.config import CONFIG
+from datetime import datetime
+from xml.dom.minidom import parse
+
+addon_xmls = []
+
+def enable_addons():
+	for name in glob.glob(os.path.join(CONFIG.ADDONS,'*/addon.xml')):
+		addon_xmls.append(name)
+	addon_xmls.sort()
+	addon_ids =[]
+	for xml in addon_xmls:
+		root = parse(xml)
+		tag = root.documentElement
+		_id = tag.getAttribute('id')
+		addon_ids.append(_id)
+	enabled=[]
+	disabled=[]
+	for x in addon_ids:
+		try:
+			xbmcaddon.Addon(id = x)
+			enabled.append(x)
+		except:
+			disabled.append(x)
+	for y in disabled:
+		try:
+			xbmc.executebuiltin(EnableAddon(y))
+		except:
+			enable_db(y)
+	CONFIG.set_setting('first_postinstall', 'false')
+	
+def enable_db(d_addon):
+    """ create a database connection to a SQLite database """
+    dbfile = os.path.join(CONFIG.DATABASE, 'Addons33.db')
+    conn = None
+    conn = sqlite3.connect(dbfile)
+    c = conn.cursor()
+    try:
+    	c.execute("SELECT id, addonID, enabled FROM installed WHERE addonID = ?", (d_addon,))
+    	found = c.fetchone()
+    	if found == None:
+    		# Insert a row of data
+    		c.execute('INSERT INTO installed (addonID , enabled, installDate) VALUES (?,?,?)', (d_addon, '1', installed_date,))
+    	else:
+    		c.execute('UPDATE installed SET enabled = ? WHERE addonID = ? ', (1, d_addon,))
+    except Exception as e:
+    	log('Failed to enable %s. Reason: %s' % (d_addon, e), xbmc.LOGINFO)
+    conn.commit()
+    conn.close()

--- a/resources/libs/wizard.py
+++ b/resources/libs/wizard.py
@@ -149,6 +149,7 @@ class Wizard:
 
                 db.addon_database(CONFIG.ADDON_ID, 1)
                 db.force_check_updates(over=True)
+                CONFIG.set_setting('first_postinstall', 'true')
 
                 self.dialog.ok(CONFIG.ADDONTITLE, "[COLOR {0}]To save changes you now need to force close Kodi, Press OK to force close Kodi[/COLOR]".format(CONFIG.COLOR2))
                 tools.kill_kodi(over=True)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -16,6 +16,7 @@
         
         <!-- Hidden Settings -->
         <setting id="first_install" type="bool" label="First Install" visible="false" default="true" />
+        <setting id="first_postinstall" type="bool" label="First Post-Install" visible="false" default="false" />
         <setting id="time_started" type="number" label="Time Startup Script Last Run" visible="false" default="0" />
         <setting id="installed" type="text" label="Build Installed" visible="false" default="false" />
         <setting id="extract" type="number" label="Extract Build %" visible="false" default="100" />

--- a/startup.py
+++ b/startup.py
@@ -346,7 +346,16 @@ if tools.open_url(CONFIG.BUILDFILE, check=True) and CONFIG.get_setting('installe
     window.show_build_prompt()
 else:
     logging.log("[Current Build Check] Build Installed: {0}".format(CONFIG.BUILDNAME), level=xbmc.LOGINFO)
-    
+
+# POST-INSTALL FIRST RUN CHECK (ENABLE DISABLED ADDONS)
+if CONFIG.get_setting('first_postinstall') == 'true':
+	from resources.libs.common import addonsEnable
+	addonsEnable.enable_addons()
+	xbmc.executebuiltin('UpdateLocalAddons')
+	xbmc.executebuiltin('UpdateAddonRepos')
+	xbmc.executebuiltin("ReloadSkin()")
+	tools.reload_profile(xbmc.getInfoLabel('System.ProfileName'))
+
 # BUILD UPDATE CHECK
 buildcheck = CONFIG.get_setting('nextbuildcheck')
 if CONFIG.get_setting('buildname'):


### PR DESCRIPTION
Pasting the text I sent you as reference...

So basically the only thing that changed is Kodi itself, more specifically how it handles AutoExec. You can't just put in an autoexec.py under userdata that will run no matter what after a build installation (even when the addons database is not overwritten during installation). I implemented a rough fix that will keep your functionality/behaviour as is and will non-destructively also support builds that do not overwrite the addons database or have addons that would need to be manually enabled. I made sure to utilize functions present in the wizard, the only one that did not work is the latest_db in db.py. Should I make a pull request on an otherwise unmodified fork? If you don't like my code you can edit it.

The only thing that can be optimised is the code in AddonsEnable.py as it has a hardcoded filename for the addons database. (Addons33.db)

I see a latest_db function in db.py but I did not manage to get it to work, so for the time being this only patches Addons33.db

Thanks for your correspondence.