### PR TITLE
Enable_all integration proposal #1

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.program.openwizard" name="[COLOR limegreen]Open[/COLOR]Wizard" version="2.0.2" provider-name="drinfernoo, slamious">
+<addon id="plugin.program.openwizard" name="[COLOR limegreen]Open[/COLOR]Wizard" version="2.0.3" provider-name="drinfernoo, slamious">
     <requires>
         <import addon="xbmc.python" version="3.0.0" />
         <import addon="script.module.requests" />
@@ -21,6 +21,8 @@
         <reuselanguageinvoker>false</reuselanguageinvoker>
         <source>https://www.github.com/a4k-openproject/plugin.program.openwizard/</source>
         <news>
+2.0.3
+ - Don't show previous version builds in Matrix
 2.0.2
  - Replace remaining occurences of LOGNOTICE
 2.0.1

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.program.openwizard" name="[COLOR limegreen]Open[/COLOR]Wizard" version="2.0.3.1" provider-name="drinfernoo, slamious">
+<addon id="plugin.program.openwizard" name="[COLOR limegreen]Open[/COLOR]Wizard" version="2.0.4" provider-name="drinfernoo, slamious">
     <requires>
         <import addon="xbmc.python" version="3.0.0" />
         <import addon="script.module.requests" />
@@ -21,6 +21,8 @@
         <reuselanguageinvoker>false</reuselanguageinvoker>
         <source>https://www.github.com/a4k-openproject/plugin.program.openwizard/</source>
         <news>
+2.0.4
+ - Fix leftover broken dialogs
 2.0.3
  - Don't show previous version builds in Matrix
 2.0.2

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.program.openwizard" name="[COLOR limegreen]Open[/COLOR]Wizard" version="2.0.3" provider-name="drinfernoo, slamious">
+<addon id="plugin.program.openwizard" name="[COLOR limegreen]Open[/COLOR]Wizard" version="2.0.3.1" provider-name="drinfernoo, slamious">
     <requires>
         <import addon="xbmc.python" version="3.0.0" />
         <import addon="script.module.requests" />

--- a/resources/libs/check.py
+++ b/resources/libs/check.py
@@ -384,14 +384,12 @@ def build_count():
     response = tools.open_url(CONFIG.BUILDFILE)
 
     total = 0
-    count17 = 0
-    count18 = 0
     count19 = 0
     hidden = 0
     adultcount = 0
 
     if not response:
-        return total, count17, count18, count19, adultcount, hidden
+        return total, count19, adultcount, hidden
 
     link = response.text.replace('\n', '').replace('\r', '').replace('\t', '')
     match = re.compile('name="(.+?)".+?odi="(.+?)".+?dult="(.+?)"').findall(link)
@@ -409,10 +407,6 @@ def build_count():
             total += 1
             if kodi == 19:
                 count19 += 1
-            elif kodi == 18:
-                count18 += 1
-            elif kodi == 17:
-                count17 += 1
-    return total, count17, count18, count19, adultcount, hidden
+    return total, count19, adultcount, hidden
 
 

--- a/resources/libs/clear.py
+++ b/resources/libs/clear.py
@@ -462,8 +462,8 @@ def clear_crash():
         dialog = xbmcgui.Dialog()
 
         if dialog.yesno(CONFIG.ADDONTITLE,
-                            '[COLOR {0}]Would you like to delete the Crash logs?'.format(CONFIG.COLOR2),
-                            '[COLOR {0}]{1}[/COLOR] Files Found[/COLOR]'.format(CONFIG.COLOR1, len(files)),
+                            '[COLOR {0}]Would you like to delete the Crash logs?'.format(CONFIG.COLOR2)
+                            +'\n'+'[COLOR {0}]{1}[/COLOR] Files Found[/COLOR]'.format(CONFIG.COLOR1, len(files)),
                             yeslabel="[B][COLOR springgreen]Remove Logs[/COLOR][/B]",
                             nolabel="[B][COLOR red]Keep Logs[/COLOR][/B]"):
             for f in files:
@@ -558,9 +558,9 @@ def remove_addon(addon, name, over=False, data=True):
         dialog = xbmcgui.Dialog()
         
         yes = dialog.yesno(CONFIG.ADDONTITLE,
-                               '[COLOR {0}]Are you sure you want to delete the add-on:'.format(CONFIG.COLOR2),
-                               'Name: [COLOR {0}]{1}[/COLOR]'.format(CONFIG.COLOR1, name),
-                               'ID: [COLOR {0}]{1}[/COLOR][/COLOR]'.format(CONFIG.COLOR1, addon),
+                               '[COLOR {0}]Are you sure you want to delete the add-on:'.format(CONFIG.COLOR2)
+                               +'\n'+'Name: [COLOR {0}]{1}[/COLOR]'.format(CONFIG.COLOR1, name)
+                               +'\n'+'ID: [COLOR {0}]{1}[/COLOR][/COLOR]'.format(CONFIG.COLOR1, addon),
                                yeslabel='[B][COLOR springgreen]Remove Add-on[/COLOR][/B]',
                                nolabel='[B][COLOR red]Don\'t Remove[/COLOR][/B]')
     if yes == 1:

--- a/resources/libs/common/config.py
+++ b/resources/libs/common/config.py
@@ -211,8 +211,6 @@ class Config:
         self.EXTERROR = self.get_setting('errors')
         
         # View variables
-        self.SHOW17 = self.get_setting('show17')
-        self.SHOW18 = self.get_setting('show18')
         self.SHOW19 = self.get_setting('show19')
         self.SHOWADULT = self.get_setting('adult')
         self.SEPARATE = self.get_setting('separate')

--- a/resources/libs/common/tools.py
+++ b/resources/libs/common/tools.py
@@ -216,8 +216,8 @@ def ensure_folders(folder=None):
         dialog = xbmcgui.Dialog()
 
         dialog.ok(CONFIG.ADDONTITLE,
-                      "[COLOR {0}]Error creating add-on directories:[/COLOR]".format(CONFIG.COLOR2),
-                      "[COLOR {0}]{1}[/COLOR]".format(CONFIG.COLOR1, name))
+                      "[COLOR {0}]Error creating add-on directories:[/COLOR]".format(CONFIG.COLOR2)
+                      +'\n'+"[COLOR {0}]{1}[/COLOR]".format(CONFIG.COLOR1, name))
 
 #########################
 #  Utility Functions    #

--- a/resources/libs/common/tools.py
+++ b/resources/libs/common/tools.py
@@ -397,11 +397,7 @@ def platform():
 
 
 def kodi_version():
-    if 17.0 <= CONFIG.KODIV <= 17.9:
-        vername = 'Krypton'
-    elif 18.0 <= CONFIG.KODIV <= 18.9:
-        vername = 'Leia'
-    elif 19.0 <= CONFIG.KODIV <= 19.9:
+    if 19.0 <= CONFIG.KODIV <= 19.9:
         vername = 'Matrix'
     else:
         vername = "Unknown"

--- a/resources/libs/debridit.py
+++ b/resources/libs/debridit.py
@@ -447,9 +447,9 @@ def auto_update(who):
                 dialog = xbmcgui.Dialog()
 
                 if dialog.yesno(CONFIG.ADDONTITLE,
-                                    "Would you like to save the [COLOR {0}]Debrid Info[/COLOR] for [COLOR {1}]{2}[/COLOR]?".format(CONFIG.COLOR2, CONFIG.COLOR1, n),
-                                    "Addon: [COLOR springgreen][B]{0}[/B][/COLOR]".format(u),
-                                    "Saved:[/COLOR] [COLOR red][B]{0}[/B][/COLOR]".format(su) if not su == '' else 'Saved:[/COLOR] [COLOR red][B]None[/B][/COLOR]',
+                                    "Would you like to save the [COLOR {0}]Debrid Info[/COLOR] for [COLOR {1}]{2}[/COLOR]?".format(CONFIG.COLOR2, CONFIG.COLOR1, n)
+                                    +'\n'+"Addon: [COLOR springgreen][B]{0}[/B][/COLOR]".format(u)
+                                    +'\n'+"Saved:[/COLOR] [COLOR red][B]{0}[/B][/COLOR]".format(su) if not su == '' else 'Saved:[/COLOR] [COLOR red][B]None[/B][/COLOR]',
                                     yeslabel="[B][COLOR springreen]Save Debrid[/COLOR][/B]",
                                     nolabel="[B][COLOR red]No, Cancel[/COLOR][/B]"):
                     debrid_it('update', who)

--- a/resources/libs/gui/addon_menu.py
+++ b/resources/libs/gui/addon_menu.py
@@ -196,7 +196,7 @@ class AddonMenu:
             match = tools.parse_dom(tools.read_from_file(dep), 'import', ret='addon')
             for depends in match:
                 if 'xbmc.python' not in depends:
-                    self.progress_dialog.update(0, '', '[COLOR {0}]{1}[/COLOR]'.format(CONFIG.COLOR1, depends))
+                    self.progress_dialog.update(0, '\n'+'[COLOR {0}]{1}[/COLOR]'.format(CONFIG.COLOR1, depends))
 
                     try:
                         add = tools.get_addon_by_id(id=depends)
@@ -225,8 +225,9 @@ class AddonMenu:
         self.progress_dialog.create(CONFIG.ADDONTITLE,
                                '[COLOR {0}][B]Downloading:[/B][/COLOR] [COLOR {1}]{2}[/COLOR]'.format(CONFIG.COLOR2,
                                                                                                       CONFIG.COLOR1,
-                                                                                                      plugin),
-                               '', '[COLOR {0}]Please Wait[/COLOR]'.format(CONFIG.COLOR2))
+                                                                                                      plugin)
+                               +'\n'+''
+                               +'\n'+'[COLOR {0}]Please Wait[/COLOR]'.format(CONFIG.COLOR2))
         urlsplits = url.split('/')
         lib = os.path.join(CONFIG.PACKAGES, urlsplits[-1])
 
@@ -238,9 +239,13 @@ class AddonMenu:
         Downloader().download(url, lib)
         title = '[COLOR {0}][B]Installing:[/B][/COLOR] [COLOR {1}]{2}[/COLOR]'.format(CONFIG.COLOR2, CONFIG.COLOR1,
                                                                                       plugin)
-        self.progress_dialog.update(0, title, '', '[COLOR {0}]Please Wait[/COLOR]'.format(CONFIG.COLOR2))
+        self.progress_dialog.update(0, title
+                                    +'\n'+''
+                                    +'\n'+'[COLOR {0}]Please Wait[/COLOR]'.format(CONFIG.COLOR2))
         percent, errors, error = extract.all(lib, CONFIG.ADDONS, title=title)
-        self.progress_dialog.update(0, title, '', '[COLOR {0}]Installing Dependencies[/COLOR]'.format(CONFIG.COLOR2))
+        self.progress_dialog.update(0, title
+                                    +'\n'+''
+                                    +'\n'+'[COLOR {0}]Installing Dependencies[/COLOR]'.format(CONFIG.COLOR2))
         installed(plugin)
         installlist = db.grab_addons(lib)
         logging.log(str(installlist))
@@ -359,8 +364,9 @@ class AddonMenu:
             os.makedirs(CONFIG.PACKAGES)
         
         progress_dialog.create(CONFIG.ADDONTITLE,
-                      '[COLOR {0}][B]Downloading:[/B][/COLOR] [COLOR {1}]{2}[/COLOR]'.format(CONFIG.COLOR2, CONFIG.COLOR1, name),
-                      '', '[COLOR {0}]Please Wait[/COLOR]'.format(CONFIG.COLOR2))
+                      '[COLOR {0}][B]Downloading:[/B][/COLOR] [COLOR {1}]{2}[/COLOR]'.format(CONFIG.COLOR2, CONFIG.COLOR1, name)
+                      +'\n'+''
+                      +'\n'+'[COLOR {0}]Please Wait[/COLOR]'.format(CONFIG.COLOR2))
         urlsplits = url.split('/')
         lib = xbmc.makeLegalFilename(os.path.join(CONFIG.PACKAGES, urlsplits[-1]))
         try:
@@ -369,7 +375,9 @@ class AddonMenu:
             pass
         Downloader().download(url, lib)
         title = '[COLOR {0}][B]Installing:[/B][/COLOR] [COLOR {1}]{2}[/COLOR]'.format(CONFIG.COLOR2, CONFIG.COLOR1, name)
-        progress_dialog.update(0, title, '', '[COLOR {0}]Please Wait[/COLOR]'.format(CONFIG.COLOR2))
+        progress_dialog.update(0, title
+                                +'\n'+''
+                                +'\n'+'[COLOR {0}]Please Wait[/COLOR]'.format(CONFIG.COLOR2))
         percent, errors, error = extract.all(lib, CONFIG.ADDONS, title=title)
         installed = db.grab_addons(lib)
         db.addon_database(installed, 1, True)
@@ -402,8 +410,9 @@ class AddonMenu:
             os.makedirs(CONFIG.PACKAGES)
         
         progress_dialog.create(CONFIG.ADDONTITLE,
-                      '[COLOR {0}][B]Downloading:[/B][/COLOR] [COLOR {1}]{2}[/COLOR]'.format(CONFIG.COLOR2, CONFIG.COLOR1, name),
-                      '', '[COLOR {0}]Please Wait[/COLOR]'.format(CONFIG.COLOR2))
+                      '[COLOR {0}][B]Downloading:[/B][/COLOR] [COLOR {1}]{2}[/COLOR]'.format(CONFIG.COLOR2, CONFIG.COLOR1, name)
+                      +'\n'+''
+                      +'\n'+'[COLOR {0}]Please Wait[/COLOR]'.format(CONFIG.COLOR2))
 
         urlsplits = url.split('/')
         lib = xbmc.makeLegalFilename(os.path.join(CONFIG.PACKAGES, urlsplits[-1]))
@@ -413,7 +422,9 @@ class AddonMenu:
             pass
         Downloader().download(url, lib)
         title = '[COLOR {0}][B]Installing:[/B][/COLOR] [COLOR {1}]{2}[/COLOR]'.format(CONFIG.COLOR2, CONFIG.COLOR1, name)
-        progress_dialog.update(0, title, '', '[COLOR {0}]Please Wait[/COLOR]'.format(CONFIG.COLOR2))
+        progress_dialog.update(0, title
+                                    +'\n'+''
+                                    +'\n'+'[COLOR {0}]Please Wait[/COLOR]'.format(CONFIG.COLOR2))
         percent, errors, error = extract.all(lib, CONFIG.HOME, title=title)
         installed = db.grab_addons(lib)
         db.addon_database(installed, 1, True)

--- a/resources/libs/gui/build_menu.py
+++ b/resources/libs/gui/build_menu.py
@@ -91,7 +91,7 @@ class BuildMenu:
             directory.add_file('{0}'.format(CONFIG.BUILDFILE), icon=CONFIG.ICONBUILDS, themeit=CONFIG.THEME3)
             return
 
-        total, count17, count18, count19, adultcount, hidden = check.build_count()
+        total, count19, adultcount, hidden = check.build_count()
 
         match = re.compile('name="(.+?)".+?ersion="(.+?)".+?rl="(.+?)".+?ui="(.+?)".+?odi="(.+?)".+?heme="(.+?)".+?con="(.+?)".+?anart="(.+?)".+?dult="(.+?)".+?escription="(.+?)"').findall(link)
         

--- a/resources/libs/gui/build_menu.py
+++ b/resources/libs/gui/build_menu.py
@@ -119,18 +119,6 @@ class BuildMenu:
                                        'name': 'show19'}, themeit=CONFIG.THEME3)
                     if CONFIG.SHOW19 == 'true':
                         self._list_all(match, kodiv=19)
-                if count18 > 0:
-                    state = '+' if CONFIG.SHOW18 == 'false' else '-'
-                    directory.add_file('[B]{0} Leia Builds ({1})[/B]'.format(state, count18), {'mode': 'togglesetting', 'name': 'show18'},
-                                       themeit=CONFIG.THEME3)
-                    if CONFIG.SHOW18 == 'true':
-                        self._list_all(match, kodiv=18)
-                if count17 > 0:
-                    state = '+' if CONFIG.SHOW17 == 'false' else '-'
-                    directory.add_file('[B]{0} Krypton Builds ({1})[/B]'.format(state, count17), {'mode': 'togglesetting',
-                                       'name': 'show17'}, themeit=CONFIG.THEME3)
-                    if CONFIG.SHOW17 == 'true':
-                        self._list_all(match, kodiv=17)
 
         elif hidden > 0:
             if adultcount > 0:

--- a/resources/libs/gui/menu.py
+++ b/resources/libs/gui/menu.py
@@ -527,9 +527,9 @@ def enable_addons(all=False):
                 icon = os.path.join(folder, 'icon.png') if os.path.exists(os.path.join(folder, 'icon.png')) else CONFIG.ADDON_ICON
                 fanart = os.path.join(folder, 'fanart.jpg') if os.path.exists(os.path.join(folder, 'fanart.jpg')) else CONFIG.ADDON_FANART
                 if tools.get_addon_info(addonids[i], 'name'):
-                state = "[COLOR springgreen][Enabled][/COLOR]"
-                goto = "false"
-            else:
+                    state = "[COLOR springgreen][Enabled][/COLOR]"
+                    goto = "false"
+                else:
                     state = "[COLOR red][Disabled][/COLOR]"
                     goto = "true"
 

--- a/resources/libs/install.py
+++ b/resources/libs/install.py
@@ -191,15 +191,15 @@ def fresh_start(install=None, over=False):
 
     elif install == 'restore':
         yes_pressed = dialog.yesno(CONFIG.ADDONTITLE,
-                                       "[COLOR {0}]Do you wish to restore your".format(CONFIG.COLOR2),
-                                       "Kodi configuration to default settings",
-                                       "Before installing the local backup?[/COLOR]",
+                                       "[COLOR {0}]Do you wish to restore your".format(CONFIG.COLOR2)
+                                       +'\n'+"Kodi configuration to default settings"
+                                       +'\n'+"Before installing the local backup?[/COLOR]",
                                        nolabel='[B][COLOR red]No, Cancel[/COLOR][/B]',
                                        yeslabel='[B][COLOR springgreen]Continue[/COLOR][/B]')
     elif install:
-        yes_pressed = dialog.yesno(CONFIG.ADDONTITLE, "[COLOR {0}]Do you wish to restore your".format(CONFIG.COLOR2),
-                                       "Kodi configuration to default settings",
-                                       "Before installing [COLOR {0}]{1}[/COLOR]?".format(CONFIG.COLOR1, install),
+        yes_pressed = dialog.yesno(CONFIG.ADDONTITLE, "[COLOR {0}]Do you wish to restore your".format(CONFIG.COLOR2)
+                                       +'\n'+"Kodi configuration to default settings"
+                                       +'\n'+"Before installing [COLOR {0}]{1}[/COLOR]?".format(CONFIG.COLOR1, install),
                                        nolabel='[B][COLOR red]No, Cancel[/COLOR][/B]',
                                        yeslabel='[B][COLOR springgreen]Continue[/COLOR][/B]')
     else:
@@ -280,8 +280,8 @@ def install_apk(name, url):
             yes = False
         else:
             yes = dialog.yesno(CONFIG.ADDONTITLE,
-                                   "[COLOR {0}]Would you like to download and install: ".format(CONFIG.COLOR2),
-                                   "[COLOR {0}]{1}[/COLOR]".format(CONFIG.COLOR1, name),
+                                   "[COLOR {0}]Would you like to download and install: ".format(CONFIG.COLOR2)
+                                   +'\n'+"[COLOR {0}]{1}[/COLOR]".format(CONFIG.COLOR1, name),
                                    yeslabel="[B][COLOR springgreen]Download[/COLOR][/B]",
                                    nolabel="[B][COLOR red]Cancel[/COLOR][/B]")
                                    
@@ -298,8 +298,9 @@ def install_apk(name, url):
                 return
                 
             progress_dialog.create(CONFIG.ADDONTITLE,
-                          '[COLOR {0}][B]Downloading:[/B][/COLOR] [COLOR {1}]{2}[/COLOR]'.format(CONFIG.COLOR2, CONFIG.COLOR1, apk),
-                          '', 'Please Wait')
+                          '[COLOR {0}][B]Downloading:[/B][/COLOR] [COLOR {1}]{2}[/COLOR]'.format(CONFIG.COLOR2, CONFIG.COLOR1, apk)
+                          +'\n'+''
+                          +'\n'+'Please Wait')
             
             try:
                 os.remove(lib)

--- a/resources/libs/loginit.py
+++ b/resources/libs/loginit.py
@@ -891,9 +891,9 @@ def auto_update(who):
                 dialog = xbmcgui.Dialog()
 
                 if dialog.yesno(CONFIG.ADDONTITLE,
-                                    "Would you like to save the [COLOR {0}]Login Info[/COLOR] for [COLOR {1}]{2}[/COLOR]?".format(CONFIG.COLOR2, CONFIG.COLOR1, n),
-                                    "Addon: [COLOR springgreen][B]{0}[/B][/COLOR]".format(u),
-                                    "Saved:[/COLOR] [COLOR red][B]{0}[/B][/COLOR]".format(su) if not su == '' else 'Saved:[/COLOR] [COLOR red][B]None[/B][/COLOR]',
+                                    "Would you like to save the [COLOR {0}]Login Info[/COLOR] for [COLOR {1}]{2}[/COLOR]?".format(CONFIG.COLOR2, CONFIG.COLOR1, n)
+                                    +'\n'+"Addon: [COLOR springgreen][B]{0}[/B][/COLOR]".format(u)
+                                    +'\n'+"Saved:[/COLOR] [COLOR red][B]{0}[/B][/COLOR]".format(su) if not su == '' else 'Saved:[/COLOR] [COLOR red][B]None[/B][/COLOR]',
                                     yeslabel="[B][COLOR springgreen]Save Data[/COLOR][/B]",
                                     nolabel="[B][COLOR red]No Cancel[/COLOR][/B]"):
                     login_it('update', who)

--- a/resources/libs/qr.py
+++ b/resources/libs/qr.py
@@ -45,8 +45,8 @@ def create_code():
     
     if not response:
         if not dialog.yesno(CONFIG.ADDONTITLE,
-                                "[COLOR {0}]It seems the URL you entered either isn't valid or isn\'t working, Would you like to create it anyways?[/COLOR]".format(CONFIG.COLOR2),
-                                "[COLOR {0}]{1}[/COLOR]".format(CONFIG.COLOR1, url),
+                                "[COLOR {0}]It seems the URL you entered either isn't valid or isn\'t working, Would you like to create it anyways?[/COLOR]".format(CONFIG.COLOR2)
+                                +'\n'+"[COLOR {0}]{1}[/COLOR]".format(CONFIG.COLOR1, url),
                                 yeslabel="[B][COLOR red]Yes Create[/COLOR][/B]",
                                 nolabel="[B][COLOR springgreen]No Cancel[/COLOR][/B]"):
             return
@@ -54,5 +54,5 @@ def create_code():
     name = "QR_Code_{0}".format(tools.id_generator(6)) if name == "" else name
     image = generate_code(url, name)
     dialog.ok(CONFIG.ADDONTITLE,
-                  "[COLOR {0}]The QR Code image has been created and is located in the addon_data directory:[/COLOR]".format(CONFIG.COLOR2),
-                  "[COLOR {0}]{1}[/COLOR]".format(CONFIG.COLOR1, image.replace(CONFIG.HOME, '')))
+                  "[COLOR {0}]The QR Code image has been created and is located in the addon_data directory:[/COLOR]".format(CONFIG.COLOR2)
+                  +'\n'+"[COLOR {0}]{1}[/COLOR]".format(CONFIG.COLOR1, image.replace(CONFIG.HOME, '')))

--- a/resources/libs/save.py
+++ b/resources/libs/save.py
@@ -219,5 +219,5 @@ def export_save_data():
     zipf.close()
     
     dialog.ok(CONFIG.ADDONTITLE,
-                  "[COLOR {0}]Save data has been backed up to:[/COLOR]".format(CONFIG.COLOR2),
-                  "[COLOR {0}]{1}[/COLOR]".format(CONFIG.COLOR1, os.path.join(source, 'SaveData.zip')))
+                  "[COLOR {0}]Save data has been backed up to:[/COLOR]".format(CONFIG.COLOR2)
+                  +'\n'+"[COLOR {0}]{1}[/COLOR]".format(CONFIG.COLOR1, os.path.join(source, 'SaveData.zip')))

--- a/resources/libs/traktit.py
+++ b/resources/libs/traktit.py
@@ -365,9 +365,9 @@ def auto_update(who):
                 dialog = xbmcgui.Dialog()
 
                 if dialog.yesno(CONFIG.ADDONTITLE,
-                                    "Would you like to save the [COLOR {0}]Trakt Data[/COLOR] for [COLOR {1}]{2}[/COLOR]?".format(CONFIG.COLOR2, CONFIG.COLOR1, n),
-                                    "Addon: [COLOR springgreen][B]{0}[/B][/COLOR]".format(u),
-                                    "Saved:[/COLOR] [COLOR red][B]{0}[/B][/COLOR]".format(su) if not su == '' else 'Saved:[/COLOR] [COLOR red][B]None[/B][/COLOR]',
+                                    "Would you like to save the [COLOR {0}]Trakt Data[/COLOR] for [COLOR {1}]{2}[/COLOR]?".format(CONFIG.COLOR2, CONFIG.COLOR1, n)
+                                    +'\n'+"Addon: [COLOR springgreen][B]{0}[/B][/COLOR]".format(u)
+                                    +'\n'+"Saved:[/COLOR] [COLOR red][B]{0}[/B][/COLOR]".format(su) if not su == '' else 'Saved:[/COLOR] [COLOR red][B]None[/B][/COLOR]',
                                     yeslabel="[B][COLOR springgreen]Save Data[/COLOR][/B]",
                                     nolabel="[B][COLOR red]No Cancel[/COLOR][/B]"):
                     trakt_it('update', who)

--- a/resources/libs/update.py
+++ b/resources/libs/update.py
@@ -44,8 +44,8 @@ def wizard_update():
             return
         if ver > CONFIG.ADDON_VERSION:
             yes = dialog.yesno(CONFIG.ADDONTITLE,
-                                   '[COLOR {0}]There is a new version of the {1}!'.format(CONFIG.COLOR2, CONFIG.ADDONTITLE),
-                                   'Would you like to download [COLOR {0}]v{1}[/COLOR]?[/COLOR]'.format(CONFIG.COLOR1, ver),
+                                   '[COLOR {0}]There is a new version of the {1}!'.format(CONFIG.COLOR2, CONFIG.ADDONTITLE)
+                                   +'\n'+'Would you like to download [COLOR {0}]v{1}[/COLOR]?[/COLOR]'.format(CONFIG.COLOR1, ver),
                                    nolabel='[B][COLOR red]Remind Me Later[/COLOR][/B]',
                                    yeslabel="[B][COLOR springgreen]Update Wizard[/COLOR][/B]")
             if yes:
@@ -53,8 +53,9 @@ def wizard_update():
                 from resources.libs.common import tools
 
                 logging.log("[Auto Update Wizard] Installing wizard v{0}".format(ver))
-                progress_dialog.create(CONFIG.ADDONTITLE, '[COLOR {0}]Downloading Update...'.format(CONFIG.COLOR2), '',
-                              'Please Wait[/COLOR]')
+                progress_dialog.create(CONFIG.ADDONTITLE, '[COLOR {0}]Downloading Update...'.format(CONFIG.COLOR2)
+                                        +'\n'+''
+                                        +'\n'+'Please Wait[/COLOR]')
                 lib = os.path.join(CONFIG.PACKAGES, '{0}-{1}.zip'.format(CONFIG.ADDON_ID, ver))
                 try:
                     os.remove(lib)
@@ -64,7 +65,7 @@ def wizard_update():
                 from resources.libs import extract
                 Downloader().download(zip, lib)
                 xbmc.sleep(2000)
-                progress_dialog.update(0, "", "Installing {0} update".format(CONFIG.ADDONTITLE))
+                progress_dialog.update(0, '\n'+"Installing {0} update".format(CONFIG.ADDONTITLE))
                 percent, errors, error = extract.all(lib, CONFIG.ADDONS, True)
                 progress_dialog.close()
                 xbmc.sleep(1000)

--- a/resources/libs/whitelist.py
+++ b/resources/libs/whitelist.py
@@ -194,8 +194,8 @@ def whitelist(do):
         try:
             xbmcvfs.copy(CONFIG.WHITELIST, os.path.join(source, 'whitelist.txt'))
             dialog.ok(CONFIG.ADDONTITLE,
-                          "[COLOR {0}]Whitelist has been exported to:[/COLOR]".format(CONFIG.COLOR2),
-                          "[COLOR {0}]{1}[/COLOR]".format(CONFIG.COLOR1, os.path.join(source, 'whitelist.txt')))
+                          "[COLOR {0}]Whitelist has been exported to:[/COLOR]".format(CONFIG.COLOR2)
+                          +'\n'+"[COLOR {0}]{1}[/COLOR]".format(CONFIG.COLOR1, os.path.join(source, 'whitelist.txt')))
             logging.log_notify(CONFIG.ADDONTITLE,
                                "[COLOR {0}]Whitelist Exported[/COLOR]".format(CONFIG.COLOR2))
         except Exception as e:
@@ -210,8 +210,8 @@ def whitelist(do):
                 whitelist(do='export')
     elif do == 'clear':
         if not dialog.yesno(CONFIG.ADDONTITLE,
-                                "[COLOR {0}]Are you sure you want to clear your whitelist?".format(CONFIG.COLOR2),
-                                "This process can't be undone.[/COLOR]",
+                                "[COLOR {0}]Are you sure you want to clear your whitelist?".format(CONFIG.COLOR2)
+                                +'\n'+"This process can't be undone.[/COLOR]",
                                 yeslabel="[B][COLOR springgreen]Yes Remove[/COLOR][/B]",
                                 nolabel="[B][COLOR red]No Cancel[/COLOR][/B]"):
             logging.log_notify(CONFIG.ADDONTITLE,

--- a/resources/libs/wizard.py
+++ b/resources/libs/wizard.py
@@ -149,6 +149,8 @@ class Wizard:
 
                 db.addon_database(CONFIG.ADDON_ID, 1)
                 db.force_check_updates(over=True)
+                if os.path.exists(os.path.join(CONFIG.USERDATA, '.enableall')):
+                	CONFIG.set_setting('enable_addons', 'true')
 
                 self.dialog.ok(CONFIG.ADDONTITLE, "[COLOR {0}]To save changes you now need to force close Kodi, Press OK to force close Kodi[/COLOR]".format(CONFIG.COLOR2))
                 tools.kill_kodi(over=True)

--- a/resources/libs/wizard.py
+++ b/resources/libs/wizard.py
@@ -150,7 +150,7 @@ class Wizard:
                 db.addon_database(CONFIG.ADDON_ID, 1)
                 db.force_check_updates(over=True)
                 if os.path.exists(os.path.join(CONFIG.USERDATA, '.enableall')):
-                	CONFIG.set_setting('enable_addons', 'true')
+                	CONFIG.set_setting('enable_all', 'true')
 
                 self.dialog.ok(CONFIG.ADDONTITLE, "[COLOR {0}]To save changes you now need to force close Kodi, Press OK to force close Kodi[/COLOR]".format(CONFIG.COLOR2))
                 tools.kill_kodi(over=True)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -9,8 +9,6 @@
         <setting id="nextbuildcheck" type="text" label="Next check for build update: " enable="false" default="2019-01-01 00:00:00" />
         <setting id="disableupdate" type="bool" label="Disable Update Notification" default="false"/>
         <setting type="lsep" label="Show Builds:"/>
-        <setting id="show17" type="bool" label="Show Krypton (v17.0) Builds" default="true"/>
-        <setting id="show18" type="bool" label="Show Leia (v18.0) Builds" default="true"/>
         <setting id="show19" type="bool" label="Show Matrix (v19.0) Builds" default="true"/>
         <setting id="separate" type="bool" label="Do not separate based off version" default="false"/>
         

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -14,6 +14,7 @@
         
         <!-- Hidden Settings -->
         <setting id="first_install" type="bool" label="First Install" visible="false" default="true" />
+        <setting id="enable_all" type="bool" label="Enable all Add-ons on Start" visible="false" default="false" />
         <setting id="time_started" type="number" label="Time Startup Script Last Run" visible="false" default="0" />
         <setting id="installed" type="text" label="Build Installed" visible="false" default="false" />
         <setting id="extract" type="number" label="Extract Build %" visible="false" default="100" />
@@ -165,7 +166,6 @@
         <setting id="keeplogin" type="bool" label="Keep My Login Data" default="true"/>
         <setting id="loginnextsave" type="text" label="Last Time Login Data Saved:" visible="!eq(-1, false)" enable="false" default="2019-01-01 00:00:00"/>
         <setting type="lsep" label="Keep Settings When Installing Build:"/>
-        <setting id="enable_all" type="bool" label="Enable all Add-ons on Start" default="false" />
         <setting id="keepfavourites" type="bool" label="Keep My Favourites" default="true"/>
         <setting id="keepsources" type="bool" label="Keep My Sources" default="true"/>
         <setting id="keepprofiles" type="bool" label="Keep My Profiles" default="false"/>

--- a/startup.py
+++ b/startup.py
@@ -358,6 +358,7 @@ if CONFIG.get_setting('enable_all') == 'true':
     	xbmcvfs.delete(os.path.join(CONFIG.USERDATA, '.enableall'))
     xbmc.executebuiltin('UpdateLocalAddons')
     xbmc.executebuiltin('UpdateAddonRepos')
+    db.force_check_updates(auto=True)
     CONFIG.set_setting('enable_all', 'false')
     xbmc.executebuiltin("ReloadSkin()")
     tools.reload_profile(xbmc.getInfoLabel('System.ProfileName'))

--- a/startup.py
+++ b/startup.py
@@ -352,6 +352,15 @@ if CONFIG.get_setting('enable_all') == 'true':
     logging.log("[Post Install] Enabling all Add-ons", level=xbmc.LOGINFO)
     from resources.libs.gui import menu
     menu.enable_addons(all=True)
+    if os.path.exists(os.path.join(CONFIG.USERDATA, '.enableall')):
+    	logging.log("[Post Install] .enableall file found in userdata. Deleting..", level=xbmc.LOGINFO)
+    	import xbmcvfs
+    	xbmcvfs.delete(os.path.join(CONFIG.USERDATA, '.enableall'))
+    xbmc.executebuiltin('UpdateLocalAddons')
+    xbmc.executebuiltin('UpdateAddonRepos')
+    CONFIG.set_setting('enable_all', 'false')
+    xbmc.executebuiltin("ReloadSkin()")
+    tools.reload_profile(xbmc.getInfoLabel('System.ProfileName'))
 
 # BUILD UPDATE CHECK
 buildcheck = CONFIG.get_setting('nextbuildcheck')

--- a/startup.py
+++ b/startup.py
@@ -141,11 +141,11 @@ def installed_build_check():
         yes = dialog.yesno(CONFIG.ADDONTITLE,
                            '[COLOR {0}]{2}[/COLOR] [COLOR {1}]was not installed correctly![/COLOR]'.format(CONFIG.COLOR1,
                                                                                                    CONFIG.COLOR2,
-                                                                                                   CONFIG.BUILDNAME),
-                           ('Installed: [COLOR {0}]{1}[/COLOR] / '
+                                                                                                   CONFIG.BUILDNAME)
+                           +'\n'+('Installed: [COLOR {0}]{1}[/COLOR] / '
                             'Error Count: [COLOR {2}]{3}[/COLOR]').format(CONFIG.COLOR1, CONFIG.EXTRACT, CONFIG.COLOR1,
-                                                                          CONFIG.EXTERROR),
-                           'Would you like to try again?[/COLOR]', nolabel='[B]No Thanks![/B]',
+                                                                          CONFIG.EXTERROR)
+                           +'\n'+'Would you like to try again?[/COLOR]', nolabel='[B]No Thanks![/B]',
                            yeslabel='[B]Retry Install[/B]')
         CONFIG.clear_setting('build')
         if yes:
@@ -168,14 +168,14 @@ def installed_build_check():
             if not response:
                 logging.log("[Build Installed Check] Guifix was set to http://", level=xbmc.LOGINFO)
                 dialog.ok(CONFIG.ADDONTITLE,
-                          "[COLOR {0}]It looks like the skin settings was not applied to the build.".format(CONFIG.COLOR2),
-                          "Sadly no gui fix was attached to the build",
-                          "You will need to reinstall the build and make sure to do a force close[/COLOR]")
+                          "[COLOR {0}]It looks like the skin settings was not applied to the build.".format(CONFIG.COLOR2)
+                          +'\n'+"Sadly no gui fix was attached to the build"
+                          +'\n'+"You will need to reinstall the build and make sure to do a force close[/COLOR]")
             else:
                 yes = dialog.yesno(CONFIG.ADDONTITLE,
-                                       '{0} was not installed correctly!'.format(CONFIG.BUILDNAME),
-                                       'It looks like the skin settings was not applied to the build.',
-                                       'Would you like to apply the GuiFix?',
+                                       '{0} was not installed correctly!'.format(CONFIG.BUILDNAME)
+                                       +'\n'+'It looks like the skin settings was not applied to the build.'
+                                       +'\n'+'Would you like to apply the GuiFix?',
                                        nolabel='[B]No, Cancel[/B]', yeslabel='[B]Apply Fix[/B]')
                 if yes:
                     xbmc.executebuiltin("PlayMedia(plugin://{0}/?mode=install&name={1}&url=gui)".format(CONFIG.ADDON_ID,


### PR DESCRIPTION
-wizard.py: after build extraction/install, check for a file called ".enableall" in userdata.
-startup.py: re-switch enable_addons setting to false after execution, to avoid further executions. If .enableall file is found, delete. Reload skin and profile at the end.

@drinfernoo 

Let me know what you think...