### PR TITLE
[New feature] Enable All add-ons

### DIFF
--- a/resources/libs/common/router.py
+++ b/resources/libs/common/router.py
@@ -112,6 +112,8 @@ class Router:
         elif mode == 'enableaddons':  # Maintenance - > Addon Tools -> Enable/Disable Addons
             menu.enable_addons()
             self._finish(handle)
+        elif mode == 'enableall':
+            menu.enable_addons(all=True)
         elif mode == 'toggleaddon':
             from resources.libs import db
             db.toggle_addon(name, url)

--- a/resources/libs/db.py
+++ b/resources/libs/db.py
@@ -270,15 +270,12 @@ def toggle_addon(id, value, over=None):
     response = xbmc.executeJSONRPC(query)
     
     if 'error' in response and over is None:
-        from resources.libs import update
-        
         dialog = xbmcgui.Dialog()
         
         v = 'Enabling' if value == 'true' else 'Disabling'
         dialog.ok(CONFIG.ADDONTITLE,
-                      "[COLOR {0}]Error {1} [COLOR {2}]{3}[/COLOR]".format(CONFIG.COLOR2, v, CONFIG.COLOR1, id),
+                      "[COLOR {0}]Error {1} [COLOR {2}]{3}[/COLOR]".format(CONFIG.COLOR2, v, CONFIG.COLOR1, id) + '\n' +
                       "Check to make sure the add-on list is up to date and try again.[/COLOR]")
-        update.force_update()
 
 
 def toggle_dependency(name, dp=None):

--- a/resources/libs/gui/menu.py
+++ b/resources/libs/gui/menu.py
@@ -493,12 +493,11 @@ def login_menu():
     directory.add_file('Clear All Saved Login Info', {'mode': 'clearlogin', 'name': 'all'}, icon=CONFIG.ICONLOGIN, themeit=CONFIG.THEME3)
 
 
-def enable_addons():
+def enable_addons(all=False):
     from resources.libs.common import tools
     
     from xml.etree import ElementTree
 
-    directory.add_file("[I][B][COLOR red]!!Notice: Disabling Some Addons Can Cause Issues!![/COLOR][/B][/I]", icon=CONFIG.ICONMAINT)
     fold = glob.glob(os.path.join(CONFIG.ADDONS, '*/'))
     addonnames = []
     addonids = []
@@ -515,25 +514,31 @@ def enable_addons():
             root = ElementTree.parse(xml).getroot()
             addonid = root.get('id')
             addonname = root.get('name')
-           
-            try:
-                addonnames.append(tools.get_addon_info(addonid, 'name'))
-                addonids.append(addonid)
-            except:                
-                pass
-                
-            if xbmc.getCondVisibility('System.HasAddon({0})'.format(addonid)):
-                state = "[COLOR springgreen][Enabled][/COLOR]"
-                goto = "false"
-            else:
-                state = "[COLOR red][Disabled][/COLOR]"
-                goto = "true"
-                
-            icon = os.path.join(folder, 'icon.png') if os.path.exists(os.path.join(folder, 'icon.png')) else CONFIG.ADDON_ICON
-            fanart = os.path.join(folder, 'fanart.jpg') if os.path.exists(os.path.join(folder, 'fanart.jpg')) else CONFIG.ADDON_FANART
-            directory.add_file("{0} {1}".format(state, addonname), {'mode': 'toggleaddon', 'name': addonid, 'url': goto}, icon=icon, fanart=fanart)
-    if len(addonnames) == 0:
-        directory.add_file("No Addons Found to Enable or Disable.", icon=CONFIG.ICONMAINT)
+            addonids.append(addonid)
+            addonnames.append(addonname)
+    if not all:
+        if len(addonids) == 0:
+            directory.add_file("No Addons Found to Enable or Disable.", icon=CONFIG.ICONMAINT)
+        else:
+            directory.add_file("[I][B][COLOR red]!!Notice: Disabling Some Addons Can Cause Issues!![/COLOR][/B][/I]", icon=CONFIG.ICONMAINT)
+            directory.add_dir('Enable All Addons', {'mode': 'enableall'}, icon=CONFIG.ICONMAINT, themeit=CONFIG.THEME3)
+            for i in range(0, len(addonids)):
+                folder = os.path.join(CONFIG.ADDONS, addonids[i])
+                icon = os.path.join(folder, 'icon.png') if os.path.exists(os.path.join(folder, 'icon.png')) else CONFIG.ADDON_ICON
+                fanart = os.path.join(folder, 'fanart.jpg') if os.path.exists(os.path.join(folder, 'fanart.jpg')) else CONFIG.ADDON_FANART
+                if tools.get_addon_info(addonids[i], 'name'):
+                    state = "[COLOR springgreen][Enabled][/COLOR]"
+                    goto = "false"
+                else:
+                    state = "[COLOR red][Disabled][/COLOR]"
+                    goto = "true"
+
+                directory.add_file("{0} {1}".format(state, addonnames[i]), {'mode': 'toggleaddon', 'name': addonids[i], 'url': goto}, icon=icon, fanart=fanart)
+    else:
+        from resources.libs import db
+        for addonid in addonids:
+            db.toggle_addon(addonid, 'true')
+        xbmc.executebuiltin('Container.Refresh()')
 
 
 def remove_addon_data_menu():

--- a/resources/libs/wizard.py
+++ b/resources/libs/wizard.py
@@ -149,6 +149,8 @@ class Wizard:
 
                 db.addon_database(CONFIG.ADDON_ID, 1)
                 db.force_check_updates(over=True)
+                if os.path.exists(os.path.join(CONFIG.USERDATA, '.enableall')):
+                	CONFIG.set_setting('enable_all', 'true')
 
                 self.dialog.ok(CONFIG.ADDONTITLE, "[COLOR {0}]To save changes you now need to force close Kodi, Press OK to force close Kodi[/COLOR]".format(CONFIG.COLOR2))
                 tools.kill_kodi(over=True)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -14,6 +14,7 @@
         
         <!-- Hidden Settings -->
         <setting id="first_install" type="bool" label="First Install" visible="false" default="true" />
+        <setting id="enable_all" type="bool" label="Enable all Add-ons on Start" visible="false" default="false" />
         <setting id="time_started" type="number" label="Time Startup Script Last Run" visible="false" default="0" />
         <setting id="installed" type="text" label="Build Installed" visible="false" default="false" />
         <setting id="extract" type="number" label="Extract Build %" visible="false" default="100" />

--- a/startup.py
+++ b/startup.py
@@ -346,7 +346,23 @@ if tools.open_url(CONFIG.BUILDFILE, check=True) and CONFIG.get_setting('installe
     window.show_build_prompt()
 else:
     logging.log("[Current Build Check] Build Installed: {0}".format(CONFIG.BUILDNAME), level=xbmc.LOGINFO)
-    
+
+# ENABLE ALL ADDONS AFTER INSTALL
+if CONFIG.get_setting('enable_all') == 'true':
+    logging.log("[Post Install] Enabling all Add-ons", level=xbmc.LOGINFO)
+    from resources.libs.gui import menu
+    menu.enable_addons(all=True)
+    if os.path.exists(os.path.join(CONFIG.USERDATA, '.enableall')):
+    	logging.log("[Post Install] .enableall file found in userdata. Deleting..", level=xbmc.LOGINFO)
+    	import xbmcvfs
+    	xbmcvfs.delete(os.path.join(CONFIG.USERDATA, '.enableall'))
+    xbmc.executebuiltin('UpdateLocalAddons')
+    xbmc.executebuiltin('UpdateAddonRepos')
+    db.force_check_updates(auto=True)
+    CONFIG.set_setting('enable_all', 'false')
+    xbmc.executebuiltin("ReloadSkin()")
+    tools.reload_profile(xbmc.getInfoLabel('System.ProfileName'))
+
 # BUILD UPDATE CHECK
 buildcheck = CONFIG.get_setting('nextbuildcheck')
 if CONFIG.get_setting('buildname'):


### PR DESCRIPTION
This will enable all add-ons after build install if a file called ".enableall" is found within userdata folder. The file gets deleted afterwards. It also adds an "Enable All" button within the add-on actions menu of the wizard.

Most of the credits go to @drinfernoo , as per our arrangement, I am doing a git merge --squash to make changes easily trackable within a single commit.